### PR TITLE
Remove Monaco duplication

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/DMNClientEntryPoint.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/DMNClientEntryPoint.java
@@ -28,6 +28,5 @@ public class DMNClientEntryPoint {
     @PostConstruct
     public void init() {
         PatternFlyBootstrapper.ensureMomentIsAvailable();
-        PatternFlyBootstrapper.ensureMonacoEditorLoaderIsAvailable();
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/pom.xml
@@ -831,6 +831,20 @@
               </target>
             </configuration>
           </execution>
+          <execution>
+            <id>Remove unused appformer-js-monaco assets</id>
+            <phase>install</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <tasks>
+                <delete>
+                  <fileset dir="${project.build.directory}/kie-wb-common-dmn-webapp-kogito-runtime/org.kie.workbench.common.dmn.showcase.DMNKogitoRuntimeWebapp/appformer-js-monaco" includes="**/*" />
+                </delete>
+              </tasks>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
     </plugins>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/main/webapp/index.html
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/main/webapp/index.html
@@ -37,6 +37,7 @@
 <body>
 <script>
     erraiBusRemoteCommunicationEnabled = false;
+    window.monaco = window.__KIE__DMN_LOADER__.Monaco;
 
     // kogito-editors-js - Stylesheet files
     wireStyle('kogito-editors-js/dmn-loader.css');

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/main/webapp/editor.html
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/main/webapp/editor.html
@@ -40,6 +40,7 @@
         <script type="text/javascript">
 
             erraiBusRemoteCommunicationEnabled = false;
+            window.monaco = window.__KIE__DMN_LOADER__.Monaco;
 
             // kogito-editors-js - Stylesheet files
             wireStyle('kogito-editors-js/dmn-loader.css');

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/StunnerBPMNEntryPoint.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/StunnerBPMNEntryPoint.java
@@ -44,7 +44,6 @@ import org.kie.workbench.common.stunner.bpmn.definition.StartTimerEvent;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.forms.client.formFilters.FormFiltersProviderFactory;
 import org.kie.workbench.common.stunner.forms.client.formFilters.StunnerFormElementFilterProvider;
-import org.uberfire.client.views.pfly.sys.PatternFlyBootstrapper;
 
 @EntryPoint
 @Bundle("resources/i18n/StunnerBPMNConstants.properties")
@@ -62,8 +61,6 @@ public class StunnerBPMNEntryPoint {
 
     @PostConstruct
     public void init() {
-        PatternFlyBootstrapper.ensureMonacoEditorLoaderIsAvailable();
-
         FormFiltersProviderFactory.registerProvider(new StartEventFilterProvider(sessionManager, StartNoneEvent.class));
         FormFiltersProviderFactory.registerProvider(new StartEventFilterProvider(sessionManager, StartCompensationEvent.class));
         FormFiltersProviderFactory.registerProvider(new StartEventFilterProvider(sessionManager, StartSignalEvent.class));

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/main/webapp/index.html
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/main/webapp/index.html
@@ -22,6 +22,7 @@
     <title>BPMN Editor Showcase</title>
     <link rel="stylesheet"
           href="org.kie.workbench.common.stunner.kogito.KogitoBPMNEditor/css/patternfly.min.css">
+    <script type="text/javascript" src="org.kie.workbench.common.stunner.kogito.KogitoBPMNEditor/appformer-js-monaco/monaco.min.js"></script>
 </head>
 <body>
 <!-- To turn off/on remote communication in the client bus -->

--- a/kogito-editors-js/packages/dmn-loader/src/index.tsx
+++ b/kogito-editors-js/packages/dmn-loader/src/index.tsx
@@ -33,6 +33,7 @@ import * as React from "react";
 import { useEffect, useState } from "react";
 import * as ReactDOM from "react-dom";
 import { setupWire } from "./wire";
+import * as Monaco from "monaco-editor";
 
 setupWire();
 
@@ -104,4 +105,4 @@ const renderHelloWorld = (selector: string) => {
   ReactDOM.render(<HelloWorld />, document.querySelector(selector));
 };
 
-export { renderHelloWorld, renderBoxedExpressionEditor };
+export { renderHelloWorld, renderBoxedExpressionEditor, Monaco };

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/sys/PatternFlyBootstrapper.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/sys/PatternFlyBootstrapper.java
@@ -34,8 +34,6 @@ public class PatternFlyBootstrapper {
 
     private static boolean isPatternFlyLoaded = false;
 
-    private static boolean isMonacoEditorLoaded = false;
-
     /**
      * Uses GWT's ScriptInjector to put jQuery in the page if it isn't already. All Errai IOC beans that rely on
      * GWTBootstrap 3 widgets should call this before creating their first such widget.
@@ -87,18 +85,8 @@ public class PatternFlyBootstrapper {
         }
     }
 
-    public static void ensureMonacoEditorLoaderIsAvailable() {
-        if (!isMonacoEditorLoaded) {
-            ScriptInjector.fromString(PatternFlyClientBundle.INSTANCE.monacoEditor().getText())
-                    .setWindow(ScriptInjector.TOP_WINDOW)
-                    .inject();
-            isMonacoEditorLoaded = true;
-        }
-    }
-
     /**
      * Checks to see if jQuery is already present.
-     *
      * @return true is jQuery is loaded, false otherwise.
      */
     private static native boolean isjQueryLoaded() /*-{


### PR DESCRIPTION
Hey @vpellegrino :)

Here's the summary of this PR:
- We're removing the `PatternFlyBootstrapper.ensureMonacoEditorLoaderIsAvailable` method to decrease 2MB in the size of DMN GWT files (now Monaco is not being incorporated on GWT final JS files anymore)
- On the BPMN side, we're using a different approach for loading Monaco (as BPMN doesn't have its loader, we require the `monaco.min.js` in the BPMN HTML file
- On the DMN side, we're relying on DMN loader Monaco, and also we're removing the `monaco.min.js` in the `pom.xml` (which saves more 2MB in the DMN final bundle)

